### PR TITLE
If data is in nifti objects, it might need to be read into array.

### DIFF
--- a/AFQ/api/bundle_dict.py
+++ b/AFQ/api/bundle_dict.py
@@ -66,7 +66,7 @@ class BundleDict(MutableMapping):
                  bundle_info=BUNDLES,
                  seg_algo="afq",
                  resample_to=None,
-                 resample_subject_to=None,
+                 resample_subject_to=False,
                  keep_in_memory=False):
         """
         Create a bundle dictionary, needed for the segmentation
@@ -100,8 +100,6 @@ class BundleDict(MutableMapping):
             If there are bundles in bundle_info with the 'space' attribute
             set to 'subject', their images (all ROIs and probability maps)
             will be resampled to the affine and shape of this image.
-            If None, the template will be overriden when passed to
-            an API class.
             If False, no resampling will be done.
             Default: None
 
@@ -519,7 +517,7 @@ class PediatricBundleDict(BundleDict):
                  bundle_info=PEDIATRIC_BUNDLES,
                  seg_algo="afq",
                  resample_to=None,
-                 resample_subject_to=None,
+                 resample_subject_to=False,
                  keep_in_memory=False):
         """
         Create a pediatric bundle dictionary, needed for the segmentation
@@ -547,8 +545,6 @@ class PediatricBundleDict(BundleDict):
             If there are ROIs with the 'space' attribute
             set to 'subject', those ROIs will be resampled to the affine
             and shape of this image.
-            If None, the template will be overriden when passed to
-            an API class.
             If False, no resampling will be done.
             Default: None
 

--- a/AFQ/data/fetch.py
+++ b/AFQ/data/fetch.py
@@ -367,7 +367,7 @@ def read_resample_roi(roi, resample_to=None, threshold=False):
     if isinstance(resample_to, str):
         resample_to = nib.load(resample_to)
 
-    if np.allclose(resample_to.affine, roi.affine):
+    if resample_to is False or np.allclose(resample_to.affine, roi.affine):
         return roi
 
     as_array = resample(

--- a/AFQ/segmentation.py
+++ b/AFQ/segmentation.py
@@ -498,6 +498,10 @@ class Segmentation:
                         self.mapping,
                         bundle_name=bundle)
                 else:
+                    if isinstance(roi, str):
+                        roi = nib.load(roi)
+                    if isinstance(roi, nib.Nifti1Image):
+                        roi = roi.get_fdata()
                     warped_roi = roi
 
                 if roi_type == 'include':
@@ -526,10 +530,6 @@ class Segmentation:
 
         # The probability map if doesn't exist is all ones with the same
         # shape as the ROIs:
-        if isinstance(roi, str):
-            roi = nib.load(roi)
-        if isinstance(roi, nib.Nifti1Image):
-            roi = roi.get_fdata()
         prob_map = bundle_entry.get(
             'prob_map', np.ones(roi.shape))
 
@@ -543,7 +543,6 @@ class Segmentation:
                 self.mapping.transform_inverse(
                     prob_map.copy(),
                     interpolation='nearest')
-
         return warped_prob_map, include_rois, exclude_rois,\
             include_roi_tols, exclude_roi_tols
 
@@ -733,7 +732,6 @@ class Segmentation:
                 for end_type in ['start', 'end']:
                     if end_type in self.bundle_dict[bundle]:
                         warped_roi = self.bundle_dict[bundle][end_type]
-
                         # Create binary masks and warp these into subject's
                         # DWI space:
                         if "space" not in self.bundle_dict[bundle]\
@@ -758,6 +756,8 @@ class Segmentation:
                                         'endpoint_ROI',
                                         bundle,
                                         f'{end_type}point_as_used.nii.gz'))
+                        else:
+                            warped_roi = warped_roi.get_fdata()
 
                         atlas_idx.append(
                             np.array(np.where(warped_roi > 0)).T)

--- a/AFQ/tasks/mapping.py
+++ b/AFQ/tasks/mapping.py
@@ -83,6 +83,10 @@ def export_rois(base_fname, results_dir, data_imap, mapping, dwi_affine):
                                 mapping,
                                 bundle_name=bundle)
                         else:
+                            if isinstance(roi, str):
+                                roi = nib.load(roi)
+                            if isinstance(roi, nib.Nifti1Image):
+                                roi = roi.get_fdata()
                             warped_roi = roi
 
                         # Cast to float32,


### PR DESCRIPTION
Based on some experiments, the issue in https://github.com/yeatmanlab/pyAFQ/issues/918 was that ROIs were stored in nifti objects, and because they didn't go through `transform_inverse_roi` the data never got read in, so we ended up with this line: https://github.com/yeatmanlab/pyAFQ/blob/master/AFQ/segmentation.py#L506 generating an include ROI that was `array([[0]])` and raised issues down the line. I think this suggested change resolves this.